### PR TITLE
Update octal literal to hex

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function clear()
 	
 	if (windows === false)
 	{
-		stdout += "\033[2J";
+		stdout += "\x1B[2J";
 	}
 	else
 	{
@@ -23,7 +23,7 @@ function clear()
 	}
 	
 	// Reset cursur
-	stdout += "\033[0f";
+	stdout += "\x1B[0f";
 	
 	process.stdout.write(stdout);
 }


### PR DESCRIPTION
Strict mode in later versions of node caused programs that use this to crash due to the octal literal with

```
my-project/node_modules/cli-clear/index.js:26
	stdout += "\033[0f";
	            ^^
SyntaxError: Octal literals are not allowed in strict mode.
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (my-project/index.js:2:13)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
```

This converts it to hex.